### PR TITLE
Add support for "Date" types and for "List" of primitive types in the schema generator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
               "selector": "WithStatement",
               "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
             }
-          ]
+          ],
+        "import/no-unresolved": ["error", { "ignore": ["graphql", "mongoose"] }]
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -733,6 +733,9 @@ const generateSchemaDefinition = (gqlType) => {
           }
         }
       }
+    } else if (fieldEntry.type.name === 'DateTime'
+      || (fieldEntry.type instanceof GraphQLNonNull && fieldEntry.type.ofType.name === 'DateTime')) {
+      schemaArg[fieldEntryName] = Date;
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-unresolved
 const graphql = require('graphql');
-// eslint-disable-next-line import/no-unresolved
 const mongoose = require('mongoose');
 
 const SimfinityError = require('./errors/simfinity.error');
@@ -732,6 +730,15 @@ const generateSchemaDefinition = (gqlType) => {
             throw new Error('A type cannot have a field of its same type and embedded');
           }
         }
+      } else if (fieldEntry.type.ofType === GraphQLString
+        || fieldEntry.type.ofType instanceof GraphQLEnumType) {
+        schemaArg[fieldEntryName] = [String];
+      } else if (fieldEntry.type.ofType === GraphQLBoolean) {
+        schemaArg[fieldEntryName] = [Boolean];
+      } else if (fieldEntry.type.ofType === GraphQLInt || fieldEntry.type.ofType === GraphQLFloat) {
+        schemaArg[fieldEntryName] = [Number];
+      } else if (fieldEntry.type.ofType.name === 'DateTime' || fieldEntry.type.ofType.name === 'Date' || fieldEntry.type.ofType.name === 'Time') {
+        schemaArg[fieldEntryName] = [Date];
       }
     } else if (fieldEntry.type.name === 'DateTime' || fieldEntry.type.name === 'Date' || fieldEntry.type.name === 'Time'
       || (fieldEntry.type instanceof GraphQLNonNull && (fieldEntry.type.ofType.name === 'DateTime'

--- a/src/index.js
+++ b/src/index.js
@@ -733,8 +733,9 @@ const generateSchemaDefinition = (gqlType) => {
           }
         }
       }
-    } else if (fieldEntry.type.name === 'DateTime'
-      || (fieldEntry.type instanceof GraphQLNonNull && fieldEntry.type.ofType.name === 'DateTime')) {
+    } else if (fieldEntry.type.name === 'DateTime' || fieldEntry.type.name === 'Date' || fieldEntry.type.name === 'Time'
+      || (fieldEntry.type instanceof GraphQLNonNull && (fieldEntry.type.ofType.name === 'DateTime'
+      || fieldEntry.type.ofType.name === 'Date' || fieldEntry.type.ofType.name === 'Time'))) {
       schemaArg[fieldEntryName] = Date;
     }
   }


### PR DESCRIPTION
In the schema generator there is no case when a enty is of type "DateTime", "Date" or "Time" all types are specified in "graphql-iso-date".
Adding an extra case.

Also in the schema generator when a list of entries is a primitive value, it's not registered.
Adding also extra cases. 

Adding a rule to eslint to not check peer dependencies.