### PR TITLE
adding support for middlewares

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1230,8 +1230,8 @@ const buildRootQuery = (name, includedTypes) => {
 
             if (args.pagination && args.pagination.count) {
               const aggregateClausesForCount = await buildQuery(args, type.gqltype, true);
-              const resultCount = type.model.aggregate(aggregateClausesForCount);
-              context.count = resultCount.size;
+              const resultCount = await type.model.aggregate(aggregateClausesForCount);
+              context.count = resultCount[0].size;
             }
 
             let result;

--- a/src/index.js
+++ b/src/index.js
@@ -1083,9 +1083,8 @@ const buildQuery = async (input, gqltype) => {
   const aggregateClauses = [];
   const matchesClauses = { $match: {} };
   let addMatch = false;
-  let limitClause = {};
-  let skipClause = {};
-  let addPagination = false;
+  let limitClause = { $limit: 100 };
+  let skipClause = { $skip: 0 };
   let sortClause = {};
   let addSort = false;
 
@@ -1117,7 +1116,6 @@ const buildQuery = async (input, gqltype) => {
         const skip = filterField.size * (filterField.page - 1);
         limitClause = { $limit: filterField.size + skip };
         skipClause = { $skip: skip };
-        addPagination = true;
       }
     } else if (key === 'sort') {
       const sortExpressions = {};
@@ -1138,12 +1136,9 @@ const buildQuery = async (input, gqltype) => {
     aggregateClauses.push(sortClause);
   }
 
-  if (addPagination) {
-    aggregateClauses.push(limitClause);
-    aggregateClauses.push(skipClause);
-  }
+  aggregateClauses.push(limitClause);
+  aggregateClauses.push(skipClause);
 
-  console.log(JSON.stringify(aggregateClauses));
   return aggregateClauses;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -676,14 +676,15 @@ const buildMutation = (name, includedMutationTypes, includedCustomMutations) => 
           type: type.gqltype,
           description: 'add',
           args: argsObject,
-          async resolve(parent, args) {
-            const context = {
+          async resolve(parent, args, context) {
+            const params = {
               type,
               args,
               operation: operations.SAVE,
+              context,
             };
 
-            excecuteMiddleware(context);
+            excecuteMiddleware(params);
             return executeOperation(type.model, type.gqltype, type.controller,
               args.input, operations.SAVE);
           },
@@ -692,14 +693,15 @@ const buildMutation = (name, includedMutationTypes, includedCustomMutations) => 
           type: type.gqltype,
           description: 'delete',
           args: { id: { type: new GraphQLNonNull(GraphQLID) } },
-          async resolve(parent, args) {
-            const context = {
+          async resolve(parent, args, context) {
+            const params = {
               type,
               args,
               operation: operations.DELETE,
+              context,
             };
 
-            excecuteMiddleware(context);
+            excecuteMiddleware(params);
             return executeOperation(type.model, type.gqltype, type.controller,
               args.id, operations.DELETE);
           },
@@ -716,14 +718,15 @@ const buildMutation = (name, includedMutationTypes, includedCustomMutations) => 
           type: type.gqltype,
           description: 'update',
           args: argsObject,
-          async resolve(parent, args) {
-            const context = {
+          async resolve(parent, args, context) {
+            const params = {
               type,
               args,
               operation: operations.UPDATE,
+              context,
             };
 
-            excecuteMiddleware(context);
+            excecuteMiddleware(params);
             return executeOperation(type.model, type.gqltype, type.controller,
               args.input, operations.UPDATE);
           },
@@ -735,16 +738,17 @@ const buildMutation = (name, includedMutationTypes, includedCustomMutations) => 
                 type: type.gqltype,
                 description: actionField.description,
                 args: argsObject,
-                async resolve(parent, args) {
-                  const context = {
+                async resolve(parent, args, context) {
+                  const params = {
                     type,
                     args,
                     operation: operations.STATE_CHANGED,
                     actionName,
                     actionField,
+                    context,
                   };
 
-                  excecuteMiddleware(context);
+                  excecuteMiddleware(params);
                   return executeOperation(type.model, type.gqltype, type.controller,
                     args.input, operations.STATE_CHANGED, actionField);
                 },
@@ -764,13 +768,14 @@ const buildMutation = (name, includedMutationTypes, includedCustomMutations) => 
         type: registeredMutation.outputModel,
         description: registeredMutation.description,
         args: argsObject,
-        async resolve(parent, args) {
-          const context = {
+        async resolve(parent, args, context) {
+          const params = {
             args,
             operation: operations.CUSTOM_MUTATION,
             entry,
+            context,
           };
-          excecuteMiddleware(context);
+          excecuteMiddleware(params);
           return executeRegisteredMutation(args.input, registeredMutation.callback);
         },
       };
@@ -1159,16 +1164,17 @@ const buildRootQuery = (name, includedTypes) => {
         rootQueryArgs.fields[type.simpleEntityEndpointName] = {
           type: type.gqltype,
           args: { id: { type: GraphQLID } },
-          resolve(parent, args) {
+          resolve(parent, args, context) {
             /* Here we define how to get data from database source
             this will return the type with id passed in argument
             by the user */
-            const context = {
+            const params = {
               type,
               args,
               operation: 'get_by_id',
+              context,
             };
-            excecuteMiddleware(context);
+            excecuteMiddleware(params);
             return type.model.findById(args.id);
           },
         };
@@ -1210,13 +1216,14 @@ const buildRootQuery = (name, includedTypes) => {
         rootQueryArgs.fields[type.listEntitiesEndpointName] = {
           type: new GraphQLList(type.gqltype),
           args: argsObject,
-          async resolve(parent, args) {
-            const context = {
+          async resolve(parent, args, context) {
+            const params = {
               type,
               args,
               operation: 'find',
+              context,
             };
-            excecuteMiddleware(context);
+            excecuteMiddleware(params);
             const aggregateClauses = await buildQuery(args, type.gqltype);
             let result;
             if (aggregateClauses.length === 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -1231,7 +1231,7 @@ const buildRootQuery = (name, includedTypes) => {
             if (args.pagination && args.pagination.count) {
               const aggregateClausesForCount = await buildQuery(args, type.gqltype, true);
               const resultCount = await type.model.aggregate(aggregateClausesForCount);
-              context.count = resultCount[0].size;
+              context.count = resultCount[0] ? resultCount[0].size : 0;
             }
 
             let result;


### PR DESCRIPTION
With this feature we will be able to define middlewares that will be executed before queries, state change, mutations and custom mutations. 
Middlewares follow the same patern than express middleware functions.
They receive as parameter the context containing the grapql request information, such as type, operation and models. Also they receive as a second parameter a next function that must be called as last line of the middleware.

This middleware can be for several operations such as adding authorization at endpoint level.